### PR TITLE
chore: calculate correct animation sizes

### DIFF
--- a/src/core/defs.ts
+++ b/src/core/defs.ts
@@ -11,7 +11,7 @@ export type AnimateStrategyReturn = {
   promise: Promise<void>,
   cancel: () => void,
 };
-export type AnimateStrategy = (panel: SplitPanel, items: SplitPanel[], size?: ConstraintType) => AnimateStrategyReturn;
+export type AnimateStrategy = (panel: SplitPanel, items: SplitPanel[], size?: ConstraintType | ConstraintType[]) => AnimateStrategyReturn;
 export type DraggableStrategyReturn<DType = any> = {
   /** The split panel currently being dragged */
   dragTarget: SplitPanel<DType>,
@@ -297,6 +297,7 @@ export function mergePanelConstraints(...constraints: ParsedPanelConstraints[]) 
     // Get the smaller of the two constraints
     maxSize: mergeConstraint(maxSize, (c1, c2) => (c1.exactValue > c2.exactValue ? 1 : -1)),
   };
+
   const normalized: ParsedPanelConstraints = {};
 
   for (const key of Object.keys(merged)) {

--- a/src/plugins/animate.ts
+++ b/src/plugins/animate.ts
@@ -8,7 +8,14 @@ import {
 import type SplitPanel from '@/core/SplitPanel';
 
 export default function configureAnimate(config?: Omit<anime.AnimeAnimParams, 'update'>): AnimateStrategy {
-  return (panel: SplitPanel, items: SplitPanel[], size?: ConstraintType | ConstraintType[]) => {
+  return (
+    /** The container panel */
+    panel: SplitPanel,
+    /** The items to animate */
+    items: SplitPanel[],
+    /** The size (or parallel array of sizes) */
+    size?: ConstraintType | ConstraintType[]
+  ) => {
     const others = negateChildren(panel, items);
     const timeline = anime.timeline({ autoplay: false });
     const newSizes = panel.calculateSizes({

--- a/src/plugins/animate.ts
+++ b/src/plugins/animate.ts
@@ -8,7 +8,7 @@ import {
 import type SplitPanel from '@/core/SplitPanel';
 
 export default function configureAnimate(config?: Omit<anime.AnimeAnimParams, 'update'>): AnimateStrategy {
-  return (panel: SplitPanel, items: SplitPanel[], size?: ConstraintType) => {
+  return (panel: SplitPanel, items: SplitPanel[], size?: ConstraintType | ConstraintType[]) => {
     const others = negateChildren(panel, items);
     const timeline = anime.timeline({ autoplay: false });
     const newSizes = panel.calculateSizes({


### PR DESCRIPTION
Resolve an issue where `minSize` wasn't taken into consideration when equalizing the panel sizes by giving a size suggestion and calculating all panel sizes based on their constraints.