### PR TITLE
fix: don't render until a size is set

### DIFF
--- a/src/core/defs.ts
+++ b/src/core/defs.ts
@@ -198,6 +198,11 @@ export function resizeEntryToBoxRect(data: ResizeObserverEntry) {
   return pick(rect, ['x', 'y', 'width', 'height']) as BoxRect;
 }
 
+export function htmlElementToBoxRect(el: HTMLElement) {
+  const rect = el.getBoundingClientRect();
+  return pick(rect, ['x', 'y', 'width', 'height']) as BoxRect;
+}
+
 export function getCoordFromMouseEvent(e: MouseEvent | TouchEvent): BoxCoord {
   if ('touches' in e) {
     return {

--- a/src/render/vue3.tsx
+++ b/src/render/vue3.tsx
@@ -56,19 +56,23 @@ const SplitPanelView = defineComponent({
               </div>
             )
         }
-        <div
-          class="split-panel-content"
-          ref={sPanel.attachContentEl}
-        >
-          {sPanel.numChildren
-            ? sPanel.children.map((child) => (
-              <SplitPanelView splitPanel={child}>{panelSlots}</SplitPanelView>
-            ))
-            : (
-              <div class="split-panel-content-inner">{this.slots.item?.(scope)}</div>
-            )
-          }
-        </div>
+        {
+          sPanel.isReady ? (
+            <div
+              class="split-panel-content"
+              ref={sPanel.attachContentEl}
+            >
+              {sPanel.numChildren
+                ? sPanel.children.map((child) => (
+                  <SplitPanelView splitPanel={child}>{ panelSlots }</SplitPanelView>
+                ))
+                : (
+                  <div class="split-panel-content-inner">{this.slots.item?.(scope)}</div>
+                )
+              }
+            </div>
+          ) : null
+        }
         {
           this.slots.ghost ? (
             <div

--- a/src/style.scss
+++ b/src/style.scss
@@ -26,6 +26,7 @@ split-panel, .split-panel {
   width: var(--sp-width);
   height: var(--sp-height);
   cursor: var(--sp-cursor);
+  opacity: var(--sp-opacity);
   position: relative;
 
   &.direction-column {


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `fix`       | Fixes an issue                                                            |  🐛  |    ✅     |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- wait to calculate the sizes until the panel has a defined width/height
- recalculate on `visibilitychange`

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
Looks like the panels were sometimes rendering with 0 width because the initial calculation happened before a defined width/height was set. This will prevent the child panels from rendering and the panel from calculating the dimensions until there is a defined width/height for the parent element.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
