### PR TITLE
add way to recalculate the panel sizes to the initial sizes

### DIFF
--- a/src/core/defs.ts
+++ b/src/core/defs.ts
@@ -355,8 +355,8 @@ export function getSizeInfo(
     comparativeSize?: number;
   },
 ) {
-  const { minSize, maxSize } = options.parsedConstraints || {};
-  const parsedSize = options.size === undefined ? undefined : parseConstraint(options.size, options.comparativeSize);
+  const { minSize, maxSize, size } = options.parsedConstraints || {};
+  const parsedSize = options.size === undefined ? size : parseConstraint(options.size, options.comparativeSize);
   let newRelativeSize = parsedSize?.relativeValue ?? options.relativeSize;
   let newSize = parsedSize?.exactValue ?? options.rectSize ?? 0;
   let useRelative = true;


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- add recalculate method

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
Sometimes the panel sizes can be incorrect if the parent element's size changes while the panel is initializing. This provides a way to recalculate the initial panel sizes

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [-] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
