### PR TITLE
chore: allow explicitly set order of panels and hook into add/remove

### DIFF
--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -118,6 +118,8 @@ export type SplitPanelArgs<DType = any> = SplitPanelDef<DType> & {
   flattenStrategy?: FlattenStrategy,
   /** Use built in resize observer or not (defaults to true) */
   observe?: boolean,
+  /** The preferred order of this panel in its parent panel */
+  order?: number | string,
   /** Starting box size */
   rect?: BoxRect,
   /** Animation duration in milliseconds */

--- a/src/render/SplitPanelBase.vue
+++ b/src/render/SplitPanelBase.vue
@@ -1,9 +1,9 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { onBeforeUnmount, computed } from 'vue';
 import SplitPanel from '@/core/SplitPanel';
 import { PanelScope, SplitPanelBaseSlots, SplitPanelBaseProps } from './interfaces';
 
-function makeScope(panel: SplitPanel): PanelScope {
+function makeScope(panel: SplitPanel<T>): PanelScope<T> {
   return { panel };
 }
 
@@ -11,8 +11,8 @@ defineOptions({
   name: 'SplitPanelBase',
 });
 
-const props = defineProps<SplitPanelBaseProps>();
-const slots = defineSlots<SplitPanelBaseSlots>();
+const props = defineProps<SplitPanelBaseProps<T>>();
+const slots = defineSlots<SplitPanelBaseSlots<T>>();
 
 onBeforeUnmount(() => {
   if (!props.manualUnbind && props.splitPanel?.isRoot) {
@@ -39,19 +39,18 @@ const resizeClasses = computed(() => ({
     :class="panelClasses"
     :style="splitPanel.style"
   >
-    <template v-if="!splitPanel.isRoot && !(splitPanel.isFirstChild && !splitPanel.showFirstResizeEl)">
-      <div
-        :ref="splitPanel.attachResizeEl"
-        :class="resizeClasses"
-      >
-        <div class="split-panel-resize-inner">
-          <slot
-            name="resize"
-            v-bind="makeScope(splitPanel)"
-          />
-        </div>
+    <div
+      v-if="!splitPanel.isRoot && !(splitPanel.isFirstChild && !splitPanel.showFirstResizeEl)"
+      :ref="splitPanel.attachResizeEl"
+      :class="resizeClasses"
+    >
+      <div class="split-panel-resize-inner">
+        <slot
+          name="resize"
+          v-bind="makeScope(splitPanel)"
+        />
       </div>
-    </template>
+    </div>
     <div
       class="split-panel-content"
       :ref="splitPanel.attachContentEl"

--- a/src/render/SplitPanelItem.vue
+++ b/src/render/SplitPanelItem.vue
@@ -1,12 +1,12 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { computed, onBeforeUnmount, inject, ShallowRef, watch } from 'vue';
 import { type SplitPanel, type PanelConstraints } from '@/core';
 
 import { SplitPanelItemProps, SplitPanelViewSlots } from './interfaces';
 import SplitPanelBase from './SplitPanelBase.vue';
 
-const props = defineProps<SplitPanelItemProps>();
-const slots = defineSlots<SplitPanelViewSlots>();
+const props = defineProps<SplitPanelItemProps<T>>();
+const slots = defineSlots<SplitPanelViewSlots<T>>();
 const splitPanelParent = inject<ShallowRef<SplitPanel>>('splitPanel');
 const [splitPanel] = splitPanelParent.value.addChild({ ...props, id: props.itemId });
 

--- a/src/render/interfaces.ts
+++ b/src/render/interfaces.ts
@@ -6,49 +6,58 @@ import {
   type SplitPanelDef,
 } from '@/core';
 
-export interface PanelScope {
-  panel: SplitPanel,
+export interface PanelScope<DType> {
+  panel: SplitPanel<DType>,
 }
 
-export interface SplitPanelBaseSlots {
-  content?: (scope: PanelScope) => any,
-  resize?: (scope: PanelScope) => any,
-  item?: (scope: PanelScope) => any,
-  ghost?: (scope: PanelScope) => any,
-  dropZone?: (scope: PanelScope) => any,
+export interface SplitPanelBaseSlots<DType> {
+  content?: (scope: PanelScope<DType>) => any,
+  resize?: (scope: PanelScope<DType>) => any,
+  item?: (scope: PanelScope<DType>) => any,
+  ghost?: (scope: PanelScope<DType>) => any,
+  dropZone?: (scope: PanelScope<DType>) => any,
   [name: string]: ((...args: any[]) => any) | undefined, // Allow other slots
 }
 
-export interface SplitPanelViewSlots {
-  resize?: (scope: PanelScope) => any,
-  default?: (scope: PanelScope) => any,
-  ghost?: (scope: PanelScope) => any,
-  dropZone?: (scope: PanelScope) => any,
-  [name: string]: (scope: PanelScope) => any,
+export interface SplitPanelViewSlots<DType> {
+  resize?: (scope: PanelScope<DType>) => any,
+  default?: (scope: PanelScope<DType>) => any,
+  ghost?: (scope: PanelScope<DType>) => any,
+  dropZone?: (scope: PanelScope<DType>) => any,
+  [name: string]: (scope: PanelScope<DType>) => any,
 }
 
-export interface SplitPanelBaseProps {
-  splitPanel: SplitPanel,
+export interface SplitPanelBaseProps<DType> {
+  splitPanel: SplitPanel<DType>,
   manualUnbind?: boolean,
   manualSlots?: boolean,
 }
 
-export interface SplitPanelViewProps extends Pick<
+export type ChildrenChangedEvent<DType> = {
+  splitPanel: SplitPanel<DType>,
+  type: 'add' | 'remove',
+  children: SplitPanelDef[],
+};
+
+export interface SplitPanelViewProps<DType> extends Pick<
   SplitPanelArgs,
   'resizeElSize' | 'showFirstResizeEl' | 'direction'
 > {
-  splitPanel?: SplitPanel,
+  itemId?: string,
+  splitPanel?: SplitPanel<DType>,
   animateStrategy?: AnimateStrategy,
   draggableStrategy?: DraggableStrategy,
 }
 
-export interface SplitPanelItemProps extends Omit<SplitPanelDef, 'id' | 'dataArray' | 'children'> {
+export interface SplitPanelItemProps<DType> extends Omit<SplitPanelDef<DType>, 'id' | 'dataArray' | 'children'> {
   /** Id of the panel. Will default to a uniquely generated id. */
   itemId?: string,
   /** Constrain the panel to fit the scroll size of the contents */
   constrainToScroll?: boolean,
+  /** The order/index of this panel in the parent panel. */
+  order?: number,
 }
 
-export interface SplitPanelItemSlots {
-  default?: (scope: PanelScope) => any,
+export interface SplitPanelItemSlots<DType> {
+  default?: (scope: PanelScope<DType>) => any,
 }


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- add the ability to explicitly set the order of the panels
- add `update:children` event
- add generic type

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
In using the new panel components, it became clear that we needed the ability to respond to when panels were added/removed, and also to force the order so the resize bars work the right 

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
