### PR TITLE
chore: prioritize size constraint

### DIFF
--- a/src/core/SplitPanel.ts
+++ b/src/core/SplitPanel.ts
@@ -1246,11 +1246,17 @@ class SplitPanel<DType = any> {
         const remaining = relativeToPercent(getRemaining(remainingToObserve.size));
         let newSize: SizeInfoType;
 
-        if (!item.hasSize || options?.initialize) {
-          newSize = item.getSizeInfo(
-            parsedToFormatted(item.parsedConstraints?.size)
-            ?? remaining
-          );
+        if (
+          !item.hasSize
+          || options?.initialize
+          || (
+            // If the item has a size constraint, try to respect it
+            item.parsedConstraints?.size != null
+            && !itemsToConstrain
+            && item.parsedConstraints?.size?.exactValue < leftToAllocate
+          )
+        ) {
+          newSize = item.getSizeInfo(parsedToFormatted(item.parsedConstraints?.size) ?? remaining);
         } else if ((item.canGrow && (growing || !itemsToConstrain)) || (item.canShrink && (shrinking || !itemsToConstrain))) {
           newSize = item.getSizeInfo(remaining);
         } else {

--- a/src/core/__spec__/SplitPanel.spec.ts
+++ b/src/core/__spec__/SplitPanel.spec.ts
@@ -212,6 +212,40 @@ describe('SplitPanel', () => {
       expect(splitPanel.byId(IDS.ID4).sizeInfo.relativeSize).toEqual(0.1);
       expect(splitPanel.byId(IDS.ID4).sizeInfo.exactSize).toEqual(100);
     });
+
+    describe('size', () => {
+      it('can keep its size if the remaining space allows it', () => {
+        const splitPanel = create4SplitPanelResizeAll();
+        const child = splitPanel.byId(IDS.ID4);
+
+        child.setConstraints({ size: 100 });
+        splitPanel.satisfyConstraints();
+        expect(splitPanel.byId(IDS.ID4).sizeInfo.relativeSize).toEqual(0.1);
+        expect(splitPanel.byId(IDS.ID4).sizeInfo.exactSize).toEqual(100);
+      });
+
+      it('shrinks its size if the other panels take up too much space', () => {
+        const splitPanel = create4SplitPanelResizeAll();
+
+        splitPanel.byId(IDS.ID1).setConstraints({ minSize: 950 });
+        splitPanel.byId(IDS.ID4).setConstraints({ size: 100 });
+        splitPanel.satisfyConstraints();
+        expect(splitPanel.byId(IDS.ID4).sizeInfo.relativeSize).toEqual(0.05);
+        expect(splitPanel.byId(IDS.ID4).sizeInfo.exactSize).toEqual(50);
+      });
+
+      it('shrinks its size if the other panels take up too much space and resizeElSize is set', () => {
+        const splitPanel = create4SplitPanelResizeAll();
+
+        splitPanel.setResizeElSize(10);
+        splitPanel.byId(IDS.ID1).setConstraints({ minSize: 950 });
+        splitPanel.byId(IDS.ID4).setConstraints({ size: 100 });
+        splitPanel.satisfyConstraints();
+        expect(splitPanel.byId(IDS.ID2).sizeInfo.relativeSize).toEqual(0.01);
+        expect(splitPanel.byId(IDS.ID3).sizeInfo.relativeSize).toEqual(0.01);
+        expect(splitPanel.byId(IDS.ID4).sizeInfo.relativeSize).toEqual(0.03);
+      });
+    });
   });
 
   describe('resizeStrategyNeighbor', () => {


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- prioritize the size constraint

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
The size constraint gets ignored a lot. This gives it a higher priority.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
