### PR TITLE
build: switch to TC39 decorators, update @madronejs/core to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "uuid": "^13.0.0"
   },
   "peerDependencies": {
-    "@madronejs/core": "^1.0.16",
+    "@madronejs/core": "^2.0.0",
     "animejs": "^4.0.2",
     "vue": "^3.5.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@madronejs/core':
-        specifier: ^1.0.16
-        version: 1.0.16
+        specifier: ^2.0.0
+        version: 2.0.0(vue@3.5.13(typescript@6.0.2))
       animejs:
         specifier: ^4.0.2
         version: 4.0.2
@@ -457,9 +457,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@madronejs/core@1.0.16':
-    resolution: {integrity: sha512-2/cuEjPcfLTraHHohSBUa7M/9kKuyCvkN6yY22WwWkBDl+X7+Xg1ToHN9jXn8IdLnxGvvDAs75lOmcIOjB0xyg==}
-    engines: {node: ^18.8, pnpm: ^8.7.0}
+  '@madronejs/core@2.0.0':
+    resolution: {integrity: sha512-ubLSa1m+So+J3OjmA59HhpWhWyeTDEEqE0SKhVAISFOYjanPizuuWyTK1Wfq5Bj4PbV8r4SnqeVKLpcv9oFlYw==}
+    engines: {node: ^22.14 || ^24.14, pnpm: '>=10'}
+    peerDependencies:
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      vue:
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2533,7 +2538,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@madronejs/core@1.0.16': {}
+  '@madronejs/core@2.0.0(vue@3.5.13(typescript@6.0.2))':
+    optionalDependencies:
+      vue: 3.5.13(typescript@6.0.2)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "strict": false,
-    "target": "ES2020",
+    "target": "ES2022",
     "jsx": "preserve",
-    "experimentalDecorators": true,
+    "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Switch to TC39 standard decorators (remove `experimentalDecorators`, enable `useDefineForClassFields`, bump `target` to `ES2022`) to match the decorator semantics now implemented by `@madronejs/core`
- Bump `@madronejs/core` peer dependency to `^2.0.0`
- Ignore `.claude/settings.local.json`

## Test plan
- [ ] `pnpm install` resolves against `@madronejs/core@2`
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes
- [ ] Demo app renders and panels drag/resize as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)